### PR TITLE
Delete button in swap layer manager

### DIFF
--- a/src/components/lists/VcsTreeNode.vue
+++ b/src/components/lists/VcsTreeNode.vue
@@ -53,7 +53,7 @@
           :disabled="item.disabled"
           right
           tooltip-position="right"
-          block-overflow
+          :block-overflow="item.blockOverflow ?? true"
           class="col-4 pa-0 ml-auto pr-4"
         />
       </slot>

--- a/src/contentTree/LayerSwap.vue
+++ b/src/contentTree/LayerSwap.vue
@@ -84,23 +84,34 @@
       };
 
       function getLayerTreeItems() {
-        return [...app.layers].filter(layerFilter).map((l) => {
-          const item = {
-            name: l.name,
-            title: l.properties?.title || l.name,
-            index: app.layers.indexOf(l),
-          };
-          if (wmsGroupItemsMap[l.name]) {
-            return {
-              ...item,
-              children: getWmsChildren(
-                l,
-                app.contentTree.getByKey(wmsGroupItemsMap[l.name]),
-              ),
+        return [...app.layers]
+          .filter(layerFilter)
+          .map((l) => {
+            const item = {
+              name: l.name,
+              title: l.properties?.title || l.name,
+              index: app.layers.indexOf(l),
+              actions: [
+                {
+                  name: 'layer-swap.delete',
+                  icon: 'mdi-delete',
+                  title: 'components.layerSwap.deleteButton',
+                  callback: () => l.deactivate(),
+                },
+              ],
+              blockOverflow: false,
             };
-          }
-          return item;
-        });
+            if (wmsGroupItemsMap[l.name]) {
+              return {
+                ...item,
+                children: getWmsChildren(
+                  l,
+                  app.contentTree.getByKey(wmsGroupItemsMap[l.name]),
+                ),
+              };
+            }
+            return item;
+          });
       }
 
       const items = shallowRef(getLayerTreeItems());

--- a/src/i18n/de.js
+++ b/src/i18n/de.js
@@ -320,6 +320,9 @@ const messages = {
       notValid: 'Eingabe nicht gültig',
       required: 'Eingabe ist erforderlich',
     },
+    layerSwap: {
+      deleteButton: 'Ebene von der Karte entfernen',
+    },
   },
   settings: {
     title: 'Einstellungen',

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -320,6 +320,9 @@ const messages = {
       notValid: 'Input not valid',
       required: 'Input is required',
     },
+    layerSwap: {
+      deleteButton: 'Remove layer from the map',
+    },
   },
   settings: {
     title: 'Settings',


### PR DESCRIPTION
This PR adds a delete button in the Swap Layer Manager component, allowing the user to rapidly remove a layer from the map via the Swap Layer Manager.

<img width="874" height="417" alt="image" src="https://github.com/user-attachments/assets/534f1c16-7df6-4eaf-a456-fd1a1f919114" />
